### PR TITLE
Add environment-based config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # Webcontrol
+
+## Environment Variables
+
+- `SECRET_KEY` – Flask secret key used for session encryption. Defaults to
+  `change-me` when not provided.
+- `VAULT_TOKEN` – Token used to authenticate to Hashicorp Vault.
+- `VAULT_URL` – (Optional) URL of the Vault server. Defaults to
+  `https://127.0.0.1:8200`.

--- a/app/services/vault/__init__.py
+++ b/app/services/vault/__init__.py
@@ -1,12 +1,13 @@
 # services/__init__.py
 
+import os
 import hvac
 
 # Configuration globale du client Vault
-vault_client = hvac.Client(
-    url="https://127.0.0.1:8200",
-    token="VaultTokenToChange",
-)
+VAULT_URL = os.environ.get("VAULT_URL", "https://127.0.0.1:8200")
+VAULT_TOKEN = os.environ.get("VAULT_TOKEN", "VaultTokenToChange")
+
+vault_client = hvac.Client(url=VAULT_URL, token=VAULT_TOKEN)
 
 # Importation des fonctions
 from .certificates import list_certificates, get_certificate_details

--- a/config.py
+++ b/config.py
@@ -1,2 +1,5 @@
+import os
+
+
 class Config:
-    SECRET_KEY="SecretKeyToChange"
+    SECRET_KEY = os.environ.get("SECRET_KEY", "change-me")


### PR DESCRIPTION
## Summary
- load Flask `SECRET_KEY` from environment
- configure Vault connection from `VAULT_TOKEN` and optional `VAULT_URL`
- document new environment variables

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68416abe60f88330b9838f9c75f05b47