### PR TITLE
Normalize VAULT_ADDR env usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The application can be configured with several environment variables:
 - `FLASK_ENV` – set to `development` to enable debug mode.
 - `SECRET_KEY` – secret key used by Flask. You can also edit `config.py` to
   change the default value.
-- `VAULT_ADDR` and `VAULT_TOKEN` – Vault server address and token if you modify
-  `app/services/vault/__init__.py` to read these values.
+- `VAULT_ADDR` – address of the Vault server used by the application.
+- `VAULT_TOKEN` – authentication token for Vault.
 - `DNS_SERVER` – address of the DNS server, defined in `app/services/dns/__init__.py`.
 
 ## Running the Application

--- a/app/services/vault/__init__.py
+++ b/app/services/vault/__init__.py
@@ -4,10 +4,14 @@ import os
 import hvac
 
 # Configuration globale du client Vault
-VAULT_URL = os.environ.get("VAULT_URL", "https://127.0.0.1:8200")
+#
+# Utilise la variable d'environnement standard "VAULT_ADDR" pour
+# déterminer l'adresse du serveur Vault. Si elle n'est pas définie,
+# une valeur par défaut est utilisée.
+VAULT_ADDR = os.environ.get("VAULT_ADDR", "https://127.0.0.1:8200")
 VAULT_TOKEN = os.environ.get("VAULT_TOKEN", "VaultTokenToChange")
 
-vault_client = hvac.Client(url=VAULT_URL, token=VAULT_TOKEN)
+vault_client = hvac.Client(url=VAULT_ADDR, token=VAULT_TOKEN)
 
 # Importation des fonctions
 from .certificates import list_certificates, get_certificate_details


### PR DESCRIPTION
## Summary
- refer to `VAULT_ADDR` consistently
- document that the application uses `VAULT_ADDR` and `VAULT_TOKEN`

## Testing
- `python -m py_compile app/services/vault/__init__.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68416e86e9608330b47fa957e595225f