### PR TITLE
Allow overriding DNS_SERVER via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ The application can be configured with several environment variables:
   change the default value.
 - `VAULT_ADDR` and `VAULT_TOKEN` – Vault server address and token if you modify
   `app/services/vault/__init__.py` to read these values.
-- `DNS_SERVER` – address of the DNS server, defined in `app/services/dns/__init__.py`.
+- `DNS_SERVER` – address of the DNS server. The value comes from the
+  `DNS_SERVER` environment variable and defaults to `127.0.0.1` (see
+  `app/services/dns/__init__.py`).
 
 ## Running the Application
 

--- a/app/services/dns/__init__.py
+++ b/app/services/dns/__init__.py
@@ -1,4 +1,6 @@
-DNS_SERVER = "127.0.0.1"
+import os
+
+DNS_SERVER = os.environ.get("DNS_SERVER", "127.0.0.1")
 
 from .zones import create_zone, delete_zone
 from .records import add_record, delete_record, list_records


### PR DESCRIPTION
## Summary
- read `DNS_SERVER` from environment in DNS service
- document DNS server override in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68416e8c4eb48330a41e38a806144ebf