### PR TITLE
Fix missing closing tags in navigation

### DIFF
--- a/templates/dns/admin.html
+++ b/templates/dns/admin.html
@@ -23,6 +23,7 @@
                         <a class="nav-link" href="{{ url_for('vault_routes.admin')}}">Administration</a>
                         <a class="nav-link" href="{{ url_for('vault_routes.list_certificates_route')}}">Certificats</a>
                     </div>
+                </li>
                 <li class="nav-item">
                     <p class="dropbox-toggle">DNS <i class="fa-solid fa-chevron-right"></i></p>
                     <div class="nav-dropbox">

--- a/templates/dns/list_records.html
+++ b/templates/dns/list_records.html
@@ -23,6 +23,7 @@
                         <a class="nav-link" href="{{ url_for('vault_routes.admin')}}">Administration</a>
                         <a class="nav-link" href="{{ url_for('vault_routes.list_certificates_route')}}">Certificats</a>
                     </div>
+                </li>
                 <li class="nav-item">
                     <p class="dropbox-toggle">DNS <i class="fa-solid fa-chevron-right"></i></p>
                     <div class="nav-dropbox">

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,7 @@
                         <a class="nav-link" href="{{ url_for('vault_routes.admin')}}">Administration</a>
                         <a class="nav-link" href="{{ url_for('vault_routes.list_certificates_route')}}">Certificats</a>
                     </div>
+                </li>
                 <li class="nav-item">
                     <p class="dropbox-toggle">DNS <i class="fa-solid fa-chevron-right"></i></p>
                     <div class="nav-dropbox">

--- a/templates/vault/admin.html
+++ b/templates/vault/admin.html
@@ -23,6 +23,7 @@
                         <a class="nav-link" href="{{ url_for('vault_routes.admin')}}">Administration</a>
                         <a class="nav-link" href="{{ url_for('vault_routes.list_certificates_route')}}">Certificats</a>
                     </div>
+                </li>
                 <li class="nav-item">
                     <p class="dropbox-toggle">DNS <i class="fa-solid fa-chevron-right"></i></p>
                     <div class="nav-dropbox">

--- a/templates/vault/list_certificates.html
+++ b/templates/vault/list_certificates.html
@@ -23,6 +23,7 @@
                         <a class="nav-link" href="{{ url_for('vault_routes.admin')}}">Administration</a>
                         <a class="nav-link" href="{{ url_for('vault_routes.list_certificates_route')}}">Certificats</a>
                     </div>
+                </li>
                 <li class="nav-item">
                     <p class="dropbox-toggle">DNS <i class="fa-solid fa-chevron-right"></i></p>
                     <div class="nav-dropbox">


### PR DESCRIPTION
## Summary
- close `<li>` after vault dropdown in navigation templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68416eb47d808330b81e21144bc75224