### PR TITLE
Fix error template structure

### DIFF
--- a/templates/error.html
+++ b/templates/error.html
@@ -1,8 +1,8 @@
-<meta charset="UTF-8">
 <!DOCTYPE html>
 <html>
 
 <head>
+    <meta charset="UTF-8">
     <title>Error</title>
 </head>
 


### PR DESCRIPTION
## Summary
- move the charset meta tag inside the `<head>` section
- place the `<!DOCTYPE html>` declaration at the top of `templates/error.html`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68416eb9296083309141ab5763dbb40e