### PR TITLE
Add Docker files for backend and frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV FLASK_APP=run.py
+EXPOSE 5000
+CMD ["flask", "run", "--host=0.0.0.0", "--port", "5000"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ python run.py
 The frontend contained in the `frontend/` directory can be served separately,
 for example using `python -m http.server`.
 
+## Docker
+
+The project provides Docker images for both the API and the web interface.
+Start them together with:
+
+```bash
+docker compose up --build
+```
+
+The API will be available on <http://localhost:5000> and the frontend on
+<http://localhost:8080>.
+
 ## Offline Assets
 
 Font Awesome styles are included in `frontend/static`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+services:
+  backend:
+    build: .
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./instance:/app/instance
+  frontend:
+    build:
+      context: ./frontend
+    ports:
+      - "8080:80"
+    depends_on:
+      - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html


### PR DESCRIPTION
## Summary
- add Dockerfile for backend API
- add Dockerfile for frontend static site
- add docker-compose configuration
- document Docker usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68756277da388330b6343485eee8d9dc